### PR TITLE
fix 500 error on evaluation API by removing a trailing comma in get_evaluation_results method

### DIFF
--- a/backend_service/src/modal_app/main.py
+++ b/backend_service/src/modal_app/main.py
@@ -198,7 +198,7 @@ async def get_evaluation_results(batch_id: str):
                     similarity_score,
                     objective_evaluation,
                     llm_feedback,
-                    prompt_id,
+                    prompt_id
                 FROM generated_images
                 WHERE batch_id = ?
                 ORDER BY prompt_text, iteration


### PR DESCRIPTION
This resolves a database error I saw in my logs after I hit the evaluation endpoint. This removes a trailing comma in the `get_evaluation_results` in `main.py`.

```bash
GET /evaluation/86b9228f-869d-4ff9-956c-2da703118041 -> 500 Internal Server Error  (duration: 127.5 ms, execution: 28.9 ms)
Database error in get_evaluation_results: near "FROM": syntax error
```

